### PR TITLE
allow using a customized URLSession

### DIFF
--- a/Sources/LoggingSlack/SlackLogHandler.swift
+++ b/Sources/LoggingSlack/SlackLogHandler.swift
@@ -18,7 +18,7 @@ public struct SlackLogHandler: LogHandler {
     internal static var messageSendHandler: ((Result<Void, Error>) -> Void)?
     
     /// Internal for testing only.
-    internal var slackSession: SlackSession = URLSession.shared
+    internal var slackSession: SlackSession
     
     /// The log label for the log handler.
     public var label: String
@@ -55,13 +55,15 @@ public struct SlackLogHandler: LogHandler {
                 channel: String? = nil,
                 username: String? = nil,
                 icon: Icon? = nil,
-                colorScheme: ColorScheme = .default) {
+                colorScheme: ColorScheme = .default,
+                slackSession: SlackSession = URLSession.shared) {
         self.label = label
         self.webhookURL = webhookURL
         self.channel = channel
         self.username = username
         self.icon = icon
         self.colorScheme = colorScheme
+        self.slackSession = slackSession
     }
     
     public subscript(metadataKey metadataKey: String) -> Logger.Metadata.Value? {

--- a/Sources/LoggingSlack/SlackMessage.swift
+++ b/Sources/LoggingSlack/SlackMessage.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-struct SlackMessage: Encodable, Equatable {
+public struct SlackMessage: Encodable, Equatable {
     let channel: String?
     let username: String?
     let text: String?

--- a/Sources/LoggingSlack/SlackSession.swift
+++ b/Sources/LoggingSlack/SlackSession.swift
@@ -3,7 +3,7 @@ import Foundation
 import FoundationNetworking
 #endif
 
-protocol SlackSession {
+public protocol SlackSession {
     func send(_ message: SlackMessage, to webhookURL: URL, completion: ((Result<Void, Error>) -> Void)?)
 }
 
@@ -13,7 +13,7 @@ enum SlackSessionError: Error {
 }
 
 extension URLSession: SlackSession {
-    func send(_ message: SlackMessage,
+    public func send(_ message: SlackMessage,
               to webhookURL: URL,
               completion: ((Result<Void, Error>) -> Void)?) {
         let data: Data


### PR DESCRIPTION
instead of using the shared URLSession, allow passing one in.

This allows users to pass a configued URLSession, e.g. one where
they set themselves as the delegate of the session.
This allows e.g. to wait for tasks to be done before exiting a console app,
so slack messages can be sent.

Given we’re adding only a default parameter, this should be backwards compatible.